### PR TITLE
Change link to CC license

### DIFF
--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -25,7 +25,7 @@
         </div>
 
         <div class="col-md-5 credits">
-            <p>All content licensed under a <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</p>
+            <p>All content licensed under a <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</p>
             
             <p>Content <i class="fab fa-creative-commons"></i> {{ .Site.Params.course.copyrightYear }} <a href="{{ .Site.Params.instructor.url }}" target="_blank" rel="noopener">{{ .Site.Params.author }}</a></p>
         


### PR DESCRIPTION
Previously linking to a Attribution-NonCommercial-ShareAlike License instead of the intended Attribution-NonCommercial-NoDerivatives License